### PR TITLE
curlybraces.xml, set.xlm: add information on Python sets (vs Processing set())

### DIFF
--- a/Reference/api_en/curlybraces.xml
+++ b/Reference/api_en/curlybraces.xml
@@ -16,6 +16,9 @@ element_names = {'H': 'hydrogen', 'He': 'helium', 'Li': 'lithium'}
 
 # Curly braces with nothing inside creates an empty dictionary
 nothing_here = {}
+
+# Curly braces with values-only create a new set
+element_set = {'H', 'He', 'Li'}
 ]]></code>
 </example>
 
@@ -24,11 +27,15 @@ Curly braces are used to define "dictionary literals," giving you the ability
 to declare a dictionary and its contents inside your program. A dictionary
 literal consists of a series of key/value pairs, written with a colon
 (<b>:</b>) between them, and with each of the key/value pairs separated from
-one other with commas.
+one other with commas. <br /> 
+<br />
+Curly braces are also used to define "sets," or a series of unique keys
+without values, separated by commas. This is not to be confused with using set() on a pixel.
 ]]></description>
 
 <syntax>
 	dict = {<c>key0: val0, ..., keyN: valN</c>}
+	set = {<c>key0, key1, ..., keyN</c>}
 </syntax>
 
 <parameter>
@@ -36,9 +43,15 @@ one other with commas.
 <description><![CDATA[a sequence of key/value pairs]]></description>
 </parameter>
 
+<parameter>
+<label>key0, key1, ..., keyN</label>
+<description><![CDATA[a sequence of unique keys]]></description>
+</parameter>
+
 <returns></returns>
 
 <related>indexbrackets</related>
+<related>set</related>
 
 <availability>1.0</availability>
 

--- a/Reference/api_en/set.xml
+++ b/Reference/api_en/set.xml
@@ -45,12 +45,21 @@ Changes the color of any pixel, or writes an image directly to the display windo
 <br />
 The <b>x</b> and <b>y</b> parameters specify the pixel to change and the <b>c</b> parameter specifies the color value. The <b>c</b> parameter is interpreted according to the current color mode.  (The default color mode is RGB values from 0 to 255.)  When setting an image, the <b>x</b> and <b>y</b> parameters define the coordinates for the upper-left corner of the image, regardless of the current <b>imageMode()</b>.
 <br /><br />
-Setting the color of a single pixel with <b>set(x, y)</b> is easy, but not as fast as putting the data directly into <b>pixels</b>. The equivalent statement to <b>set(x, y, #000000)</b> using <b>pixels</b> is <b>pixels[y*width+x] = #000000</b>. See the reference for <a href="pixels.html">pixels</a> for more information.
+Setting the color of a single pixel with <b>set(x, y)</b> is easy, but not as
+fast as putting the data directly into <b>pixels</b>. The equivalent statement
+to <b>set(x, y, #000000)</b> using <b>pixels</b> is <b>pixels[y*width+x] =
+#000000</b>. See the reference for <a href="pixels.html">pixels</a> for more
+information.<br />
+<br />
+While set(r, g, b) changes pixel color, s = set([1, 1, 3]) is a Python function
+for converting a single list or tuple into int a set of unique keys: {1, 3}.
+Sets in this sense may also be created using curly braces: s = {1, 2, 3}.
 ]]></description>
 
 <syntax>
 set(<c>x</c>, <c>y</c>, <c>c</c>)
 set(<c>x</c>, <c>y</c>, <c>img</c>)
+s = set(<c>[key0, key1, ..., keyN]</c>)
 </syntax>
 
 <parameter>
@@ -73,6 +82,12 @@ set(<c>x</c>, <c>y</c>, <c>img</c>)
 <description><![CDATA[PImage: image to copy into the original image]]></description>
 </parameter>
 
+<parameter>
+<label>[key0, key1, ..., keyN]</label>
+<description><![CDATA[a sequence of unique keys]]></description>
+</parameter>
+
 <related>pixels</related>
+<related>curlybraces</related>
 
 </root>


### PR DESCRIPTION
Adds additional examples and descriptions of s = {1, 2, 3} set syntax and s = set([1, 2, 3]) syntax to the curly braces and set pages, with cross references.

In both cases it is a bit tricky because there are two different different uses for what looks like the same construct / keyword -- a bit like the indexbrackets.xml reference page, but a bit different. See what you think of this documentation approach.

closes #66