### PR TITLE
triangle.xml: add syntax and parameters

### DIFF
--- a/Reference/api_en/triangle.xml
+++ b/Reference/api_en/triangle.xml
@@ -23,6 +23,40 @@ The "@pjs crisp" directive affects how lines are rendered. You can set it with t
 A triangle is a plane created by connecting three points. The first two arguments specify the first point, the middle two arguments specify the second point, and the last two arguments specify the third point. 
 ]]></description>
 
+<syntax>
+triangle(<c>x1</c>, <c>y1</c>, <c>x2</c>, <c>y2</c>, <c>x3</c>, <c>y3</c>)
+</syntax>
+
+<parameter>
+<label>x1</label>
+<description><![CDATA[float: x-coordinate of the first point]]></description>
+</parameter>
+
+<parameter>
+<label>y1</label>
+<description><![CDATA[float: y-coordinate of the first point]]></description>
+</parameter>
+
+<parameter>
+<label>x2</label>
+<description><![CDATA[float: x-coordinate of the second point]]></description>
+</parameter>
+
+<parameter>
+<label>y2</label>
+<description><![CDATA[float: y-coordinate of the second point]]></description>
+</parameter>
+
+<parameter>
+<label>x3</label>
+<description><![CDATA[float: x-coordinate of the third point]]></description>
+</parameter>
+
+<parameter>
+<label>y3</label>
+<description><![CDATA[float: y-coordinate of the third point]]></description>
+</parameter>
+
 <related>PShape_beginShape</related>
 <related>rect</related>
 


### PR DESCRIPTION
Syntax and parameters were missing.  Added based on java reference in same format in circle(), rect(), etc.