### PR TITLE
Update PGraphics link to "developers reference"

### DIFF
--- a/Reference/api_en/PGraphics.xml
+++ b/Reference/api_en/PGraphics.xml
@@ -25,7 +25,7 @@ image(pg, 51, 30)
 </example>
 
 <description><![CDATA[
-Main graphics and rendering context, as well as the base API implementation for processing "core". Use this class if you need to draw into an off-screen graphics buffer. A PGraphics object can be constructed with the <b>createGraphics()</b> function. The <b>beginDraw()</b> and <b>endDraw()</b> methods (see above example) are necessary to set up the buffer and to finalize it. The fields and methods for this class are extensive. For a complete list, visit the <a href="http://processing.org/reference/javadoc/core/">developer's reference.</a>
+Main graphics and rendering context, as well as the base API implementation for processing "core". Use this class if you need to draw into an off-screen graphics buffer. A PGraphics object can be constructed with the <b>createGraphics()</b> function. The <b>beginDraw()</b> and <b>endDraw()</b> methods (see above example) are necessary to set up the buffer and to finalize it. The fields and methods for this class are extensive. For a complete list, visit the <a href="http://processing.github.io/processing-javadocs/core/">developer's reference.</a>
 ]]></description>
 
 <related>createGraphics</related>


### PR DESCRIPTION
* previous url (404): https://processing.org/reference/javadoc/core/
* new url: http://processing.github.io/processing-javadocs/core/

Closes #184