### PR TITLE
added `global x` in fourth example of `fullScreen`

### DIFF
--- a/Reference/api_en/fullScreen.xml
+++ b/Reference/api_en/fullScreen.xml
@@ -86,6 +86,7 @@ def setup():
   fill(102)
 
 def draw():
+  global x
   rect(x, height*0.2, 1, height*0.6)
   x = x + 2
 ]]></code>


### PR DESCRIPTION
added `global x` in fourth example of `fullScreen` to match the first three and make it working

![image](https://user-images.githubusercontent.com/75088766/205620212-d3effcfa-93bb-4e16-97ea-998bb1c2e7ec.png)

`global x` missing:

![image](https://user-images.githubusercontent.com/75088766/205620233-ad5ec845-1708-4ac0-96e4-111dfdb110c6.png)
